### PR TITLE
refactor: prevent user from seeing biome options at max animal capacity

### DIFF
--- a/actions/release_animal.py
+++ b/actions/release_animal.py
@@ -88,18 +88,16 @@ def release_animal(arboretum):
     # setup dict and display ONLY biomes that the animal choice can go in based on requirements
     choice_dict = dict()
     actual_count = 0
-    habitats_count = 0
     for index, habitat in enumerate(animal.habitats):
         if len(arboretum.biomes[habitat]) == 0:
             continue
         else:
             actual_count += 1
-            habitats_count += 1
             choice_dict[actual_count - 1] = habitat
             print(f'{actual_count}. {habitat}')
 
     # user selects biome type
-    if habitats_count == 0:
+    if actual_count == 0:
         input('No biomes created that this animal can live in.\nPress any key and [Enter] to return to main menu to add one.')
         return
 
@@ -118,17 +116,28 @@ def release_animal(arboretum):
     clear_screen()
 
     # targets specific previously created biome list in arboretum
+    biome_dict = dict() # dictionary to store the user choice options ONLY if they have space remaining
+    actual_count = 0 # container to hold the count
     for index, biome in enumerate(arboretum.biomes[biome_type]):
         num_current_animals = len(biome.animals)
-        print(f'{index + 1}. {biome.name} [{num_current_animals} animal(s), {biome.max_animals - num_current_animals} remaining capacity]')
+        if num_current_animals == biome.max_animals: # skip this biome if it's already FULL
+            continue
+        else:             # add this BIOME to the available choices in biome_dict
+            actual_count += 1  # this helps avoid a menu starting at '2' if a previous one was skipped
+            biome_dict[actual_count - 1] = biome  # this still saves the biome to a zero-indexed dict
+            print(f'{actual_count}. {biome.name} [{num_current_animals} animal(s), {biome.max_animals - num_current_animals} remaining capacity]')
+
+    # if ALL biomes of this type full, return to main menu after notification
+    if actual_count == 0:
+        input(f'All biomes of this type are at max animal capacity.\nAnnex a new {biome_type[:-1]} habitat from the main menu.')
+        return
 
     print(f'Select the specific {biome_type[:-1]} to release the animal!')
     choice = input("> ")
 
-    new_home = ""
     try:
-        new_home = arboretum.biomes[biome_type][int(choice) - 1]
-    except (IndexError, ValueError):
+        new_home = biome_dict[int(choice) - 1] # this gets the input choice and converts back to zero-indexed choice
+    except (KeyError, ValueError):
         input("Invalid input. Return to main menu.")
         # release_animal(arboretum)
         return


### PR DESCRIPTION
# Description

Added logic for preventing the user from seeing biomes that are at max animal capacity when trying to release a new animal.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

**Make sure to commit local changes in your branch before switching to master.**
1. `git checkout master`
2. `git fetch --all`
3. `git checkout refactor/onlyShowOpenBiomes`
4. To _QUICKLY_ test this, open `Mountain.py` and change the init value from `6` to `1`. **NOTE: you will need to UNMODIFY this file back to its original state to avoid `git` trying to track the changes for you.**
5. Run the program and annex 2-3 `Mountain` biomes and GIVE THEM DIFFERENT NAMES
6. Add a Ope'ape'a 🦇 to the mountains OUT OF ORDER (ex. select 2, then 3, then 1 from what would've been the original list) and each time, make sure the previously filled biome is no longer displayed in the available options.
7. Once you have filled all the biomes, return to the main menu and print a full report and make sure each mountain only has 1 of each in it (or however many you changed the __init__ to.)

 **DON'T FORGET TO CHANGE BACK `mountain.py`** 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
